### PR TITLE
activate sort for column_def

### DIFF
--- a/R/cheetah.R
+++ b/R/cheetah.R
@@ -34,10 +34,8 @@ cheetah <- function(
       is_named_list(columns) & names(columns) %in% colnames(data)
   )
 
-  columns <-
-    update_col_list_with_classes(data, columns) %>%
-      add_field_to_list() %>%
-      toJSON(auto_unbox = TRUE)
+  columns <- update_col_list_with_classes(data, columns) %>%
+    add_field_to_list()
 
   data_json <- toJSON(data, dataframe = "rows")
   # forward options using x

--- a/R/cheetah_utils.R
+++ b/R/cheetah_utils.R
@@ -26,6 +26,8 @@
 #'   \item \code{"radio"} for radio action columns.
 #' }
 #' @param style Column style.
+#' @param sort Whether to sort the column. Default to FALSE. May also be
+#' a JS callback to create custom logic (does not work yet).
 #'
 #' @export
 #' @return A list of column options to pass to the JavaScript API.
@@ -36,7 +38,8 @@ column_def <- function(
   max_width = NULL,
   column_type = NULL,
   action = NULL,
-  style = NULL
+  style = NULL,
+  sort = FALSE
 ) {
   check_column_type(column_type)
   list(
@@ -46,6 +49,7 @@ column_def <- function(
     maxWidth = max_width,
     columnType = column_type,
     action = action,
-    style = style
+    style = style,
+    sort = sort
   )
 }

--- a/man/column_def.Rd
+++ b/man/column_def.Rd
@@ -11,7 +11,8 @@ column_def(
   max_width = NULL,
   column_type = NULL,
   action = NULL,
-  style = NULL
+  style = NULL,
+  sort = FALSE
 )
 }
 \arguments{
@@ -44,6 +45,9 @@ There are 3 supported actions:
 }}
 
 \item{style}{Column style.}
+
+\item{sort}{Whether to sort the column. Default to FALSE. May also be
+a JS callback to create custom logic (does not work yet).}
 }
 \value{
 A list of column options to pass to the JavaScript API.

--- a/vignettes/cheetahR.qmd
+++ b/vignettes/cheetahR.qmd
@@ -12,11 +12,11 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-library(dplyr)
 ```
 
 ```{r setup}
 library(cheetahR)
+library(dplyr)
 ```
 
 ## Your first table
@@ -90,4 +90,42 @@ head(airquality, 10) %>%
       )
     )
   )
+```
+
+## Sortable columns
+
+To make a column sortable, you can pass `sort = TRUE` to the `column_def()` function:
+
+```{r}
+cheetah(
+  mtcars,
+  columns = list(
+    rownames = column_def(
+      width = 150,
+      sort = TRUE
+    )
+  )
+)
+```
+
+### Coming soon (TBD)
+
+If you want finer control over the sorting logic and provide your own, you can pass a `htmlwidgets::JS` callback instead:
+
+```r
+cheetah(
+  mtcars,
+  columns = list(
+    rownames = column_def(
+      width = 150,
+      sort = htmlwidgets::JS(
+        "sort(order, col, grid) {
+          console.log(order);
+          console.log(col);
+          console.log(grid);
+        }"
+      )
+    )
+  )
+)
 ```


### PR DESCRIPTION
Fix #17. @olajoke For now, we can activate sort by passing `sort = TRUE` in `column_def()`. There is a more advanced usage which requires to pass it with `JS`  (like in DT, reactable, ...). This does not work yet, as I was unable to get it working properly:

```js
{
      field: "no",
      caption: "no",
      width: 50,
      // define custom sort logic
      sort(order, col, grid) {
        const compare =
          order === "desc"
            ? (v1, v2) => (v1 === v2 ? 0 : v1 > v2 ? 1 : -1)
            : (v1, v2) => (v1 === v2 ? 0 : v1 < v2 ? 1 : -1);
        records.sort((r1, r2) => compare(r1.no, r2.no));
        console.log("sorted:", records);
        grid.records = records;
      },
    },
    {
      field: "name",
      caption: "name",
      width: 200,
      // use default sort logic
      sort: true,
    }
```

As a side note, I removed the `toJSON` [here](https://github.com/cynkra/cheetahR/compare/f-17-sortable?expand=1#diff-7c9abd6d396ba538f65ffaf44035ff820c606bf83a520532622a49926c7afd61L40) as it does not seems useful and causes issues if we have to pass JS callbacks with the `JS` function.